### PR TITLE
changed version to 1.8.9 for compatibility

### DIFF
--- a/src/mineflayer/mineflayer.ts
+++ b/src/mineflayer/mineflayer.ts
@@ -14,7 +14,7 @@ export default class Mineflayer {
             password: env.MINECRAFT_PASSWORD,
             host: 'mc.hypixel.net',
             auth: 'microsoft',
-            version: '1.20',
+            version: '1.8.9',
             defaultChatPatterns: false,
         });
 


### PR DESCRIPTION
as of an hour ago (of writing this) hypixel removed 1.20 (.1) as a viable version for hypixel. This version of mineflayer doesnt support 1.21, so 1.8.9 was used instead, This seems to work perfectly, no flaws found immediately.